### PR TITLE
Minor fixes for frontmatter

### DIFF
--- a/control-panel/understanding-fortification/index.md
+++ b/control-panel/understanding-fortification/index.md
@@ -45,4 +45,4 @@ The following diagram illustrates normal, min, and released fortification modes 
 
 ## See Also
 
-- [Fortification](https://apnscp.com/php-fortification) (apnscp.com)
+- [Fortification](https://docs.apiscp.com/admin/Fortification/) (docs.apiscp.com)

--- a/email/mail-sent-via-127-0-0-1-rejects-relaying-denied/index.md
+++ b/email/mail-sent-via-127-0-0-1-rejects-relaying-denied/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Mail sent via 127.0.0.1 rejects with "Relaying Denied""
+title: 'Mail sent via 127.0.0.1 rejects with "Relaying Denied"'
 date: "2016-10-24"
 ---
 

--- a/python/pip-install-fails-permission-denied-python-3/index.md
+++ b/python/pip-install-fails-permission-denied-python-3/index.md
@@ -1,5 +1,5 @@
 ---
-title: "pip install fails with "Permission denied" on Python 3+"
+title: 'pip install fails with "Permission denied" on Python 3+'
 date: "2015-03-03"
 ---
 


### PR DESCRIPTION
Frontmatter fails to parse YAML heading of the markdown files when titles are malformed, usually containing invalid sequences of double apices.